### PR TITLE
Replace platform-specific modules with a shim and pkg-config

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,10 @@
 import PackageDescription
 
 let package = Package(
-    name: "CPostgreSQL"
+    name: "CPostgreSQL",
+    pkgConfig: "libpq",
+    providers: [
+        .Brew("postgresql"),
+        .Apt("libpq-dev")
+    ]
 )

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,11 +1,6 @@
-module CPostgreSQLMac [system] {
-    header "/usr/local/include/libpq-fe.h"
+module CPostgreSQL [system] {
+    header "shim.h"
     link "pq"
     export *
 }
 
-module CPostgreSQLLinux [system] {
-    header "/usr/include/postgresql/libpq-fe.h"
-    link "pq"
-    export *
-}

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,7 @@
+#ifndef __CPOSTGRESQL_SHIM_H__
+#define __CPOSTGRESQL_SHIM_H__
+
+#include <libpq-fe.h>
+
+#endif
+


### PR DESCRIPTION
This PR proposes an alternative to the hardcoded paths inside `module.modulemap`. The limitation of requiring valid and fixed paths in the mentioned file can be avoided by using `pkg-config` to look up header and library paths. (This support arrived in 3.0's SPM.)

I tested it locally and in Docker using vapor/postgresql's tests. Compilation fails if `pkg-config` is not installed, but otherwise it's working great on both OSs.

Obviously this is a breaking change in the _current form_ – CPostgreSQLMac and -Linux are now unified under a single CPostgreSQL module. If backwards compatibility is an issue, it's also possible to define both modules using the same `shim.h` file.

Having this in would also resolve #1.

Any thoughts?