### PR TITLE
Added postgres_ext.h to includes (Beta 1)

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -2,6 +2,6 @@
 #define __CPOSTGRESQL_SHIM_H__
 
 #include <libpq-fe.h>
+#include <postgres_ext.h>
 
 #endif
-


### PR DESCRIPTION
Added `postgres_ext.h` to includes, allowing to use `PG_DIAG` values in Swift